### PR TITLE
feat: EventKit バックエンド移行 + 繰り返し・場所機能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# Swift build artifacts
+swift-helper/.build/
+swift-helper/.swiftpm/

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,51 +1,138 @@
+/**
+ * apple-reminders-mcp
+ *
+ * macOS Reminders.appを操作するMCPサーバー
+ * EventKit（Swift CLI ヘルパー）経由で Reminders.app と通信する
+ *
+ * 【動作の流れ】
+ * 1. Claude Code/Desktop がこのサーバーを起動
+ * 2. サーバーは「こんなツールがあるよ」とClaudeに伝える
+ * 3. Claudeがツールを呼び出す（例: list_reminder_lists）
+ * 4. サーバーが Swift CLI ヘルパー（reminders-helper）を実行
+ * 5. ヘルパーが EventKit で Reminders.app を操作し、JSON で結果を返す
+ * 6. サーバーが結果をClaudeに返す
+ *
+ * 【バックエンド】
+ * - メイン: Swift CLI（EventKit） → 繰り返し・場所など高度な機能に対応
+ * - フォールバック: AppleScript（osascript） → フラグ設定のみ（EventKit 未対応のため）
+ */
+
+// ============================================================
+// ライブラリの読み込み
+// ============================================================
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { resolve, dirname } from "path";
 
-// osascriptを実行するヘルパー関数
-async function runAppleScript(script: string): Promise<string> {
-  const proc = Bun.spawn(["osascript", "-e", script], {
+// ============================================================
+// ヘルパー関数
+// ============================================================
+
+/**
+ * Swift CLI ヘルパーのパス
+ * swift-helper/.build/release/reminders-helper を使用
+ */
+const HELPER_PATH = resolve(
+  dirname(new URL(import.meta.url).pathname),
+  "..",
+  "swift-helper",
+  ".build",
+  "release",
+  "reminders-helper"
+);
+
+/**
+ * Swift CLI ヘルパーを実行する
+ *
+ * サブコマンドと引数を渡して実行し、JSON レスポンスを返す
+ *
+ * @param args - コマンドライン引数の配列（例: ["list-lists"]）
+ * @returns パース済みの JSON オブジェクト
+ */
+async function runHelper(args: string[]): Promise<any> {
+  const proc = Bun.spawn([HELPER_PATH, ...args], {
     stdout: "pipe",
     stderr: "pipe",
   });
+
   const stdout = await new Response(proc.stdout).text();
   const stderr = await new Response(proc.stderr).text();
   const exitCode = await proc.exited;
 
   if (exitCode !== 0) {
-    throw new Error(`AppleScript error: ${stderr}`);
+    // ヘルパーのエラー出力を確認
+    const errorMsg = stderr.trim() || stdout.trim();
+    throw new Error(`reminders-helper エラー: ${errorMsg}`);
   }
+
+  // JSON パース（ヘルパーは常に JSON を出力する）
+  try {
+    return JSON.parse(stdout.trim());
+  } catch {
+    // JSON パースに失敗した場合はテキストとして返す
+    return { text: stdout.trim() };
+  }
+}
+
+/**
+ * AppleScript を実行するヘルパー関数
+ * フラグ設定など EventKit で対応できない機能のフォールバック用
+ */
+async function runAppleScript(script: string): Promise<string> {
+  const proc = Bun.spawn(["osascript", "-e", script], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+
+  if (exitCode !== 0) {
+    throw new Error(`AppleScript エラー: ${stderr}`);
+  }
+
   return stdout.trim();
 }
 
-// MCPサーバー作成
+// ============================================================
+// MCPサーバーの作成
+// ============================================================
+
 const server = new McpServer({
   name: "apple-reminders-mcp",
-  version: "1.0.0",
+  version: "2.0.0",
 });
 
+// ============================================================
+// ツールの登録
+// ============================================================
+
+// ----------------------------------------
 // 1. リスト一覧取得
+// ----------------------------------------
 server.tool(
   "list_reminder_lists",
   "リマインダーのリスト一覧を取得",
   {},
   async () => {
-    const script = 'tell application "Reminders" to get name of every list';
-    const result = await runAppleScript(script);
-    // AppleScriptの配列形式をパース: "list1, list2, list3"
-    const lists = result.split(", ");
+    const result = await runHelper(["list-lists"]);
     return {
       content: [
         {
           type: "text" as const,
-          text: JSON.stringify(lists, null, 2),
+          text: JSON.stringify(result.lists, null, 2),
         },
       ],
     };
   }
 );
 
+// ----------------------------------------
 // 2. 特定リストのリマインダー一覧取得
+// ----------------------------------------
 server.tool(
   "get_reminders",
   "指定したリストのリマインダー一覧を取得",
@@ -58,52 +145,27 @@ server.tool(
       .describe("完了済みも含めるか"),
   },
   async ({ listName, includeCompleted }) => {
-    // 完了済みを含めるかどうかでスクリプトを変える
-    const filter = includeCompleted ? "" : " whose completed is false";
-    const script = `
-      tell application "Reminders"
-        set myList to list "${listName}"
-        set reminderData to {}
-        repeat with r in (every reminder of myList${filter})
-          set end of reminderData to {|name|:name of r, |body|:body of r, |completed|:completed of r, |dueDate|:due date of r}
-        end repeat
-        return reminderData
-      end tell
-    `;
-
-    try {
-      const result = await runAppleScript(script);
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: result || "リマインダーがありません",
-          },
-        ],
-      };
-    } catch (error) {
-      // リマインダーがない場合や期日がない場合のエラーをハンドル
-      const simpleScript = `
-        tell application "Reminders"
-          set myList to list "${listName}"
-          get name of every reminder of myList${filter}
-        end tell
-      `;
-      const result = await runAppleScript(simpleScript);
-      const reminders = result ? result.split(", ") : [];
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(reminders, null, 2),
-          },
-        ],
-      };
+    const args = ["get-reminders", "--list", listName];
+    if (includeCompleted) {
+      args.push("--include-completed");
     }
+    const result = await runHelper(args);
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: result.reminders?.length
+            ? JSON.stringify(result.reminders, null, 2)
+            : "リマインダーがありません",
+        },
+      ],
+    };
   }
 );
 
+// ----------------------------------------
 // 3. リマインダー追加
+// ----------------------------------------
 server.tool(
   "add_reminder",
   "新しいリマインダーを追加",
@@ -117,35 +179,20 @@ server.tool(
       .describe('期日（例: "2024-03-15 17:00"）'),
   },
   async ({ listName, title, body, dueDate }) => {
-    let properties = `name:"${title}"`;
-    if (body) {
-      properties += `, body:"${body}"`;
-    }
-    if (dueDate) {
-      properties += `, due date:date "${dueDate}"`;
-    }
+    const args = ["add", "--list", listName, "--title", title];
+    if (body) args.push("--body", body);
+    if (dueDate) args.push("--due-date", dueDate);
 
-    const script = `
-      tell application "Reminders"
-        tell list "${listName}"
-          make new reminder with properties {${properties}}
-        end tell
-      end tell
-    `;
-
-    await runAppleScript(script);
+    const result = await runHelper(args);
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `リマインダー「${title}」を「${listName}」に追加しました`,
-        },
-      ],
+      content: [{ type: "text" as const, text: result.message }],
     };
   }
 );
 
+// ----------------------------------------
 // 4. リマインダー完了
+// ----------------------------------------
 server.tool(
   "complete_reminder",
   "リマインダーを完了にする",
@@ -154,27 +201,20 @@ server.tool(
     reminderName: z.string().describe("リマインダー名"),
   },
   async ({ listName, reminderName }) => {
-    const script = `
-      tell application "Reminders"
-        tell list "${listName}"
-          set completed of (first reminder whose name is "${reminderName}") to true
-        end tell
-      end tell
-    `;
-
-    await runAppleScript(script);
+    const result = await runHelper([
+      "complete",
+      "--list", listName,
+      "--reminder", reminderName,
+    ]);
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `リマインダー「${reminderName}」を完了にしました`,
-        },
-      ],
+      content: [{ type: "text" as const, text: result.message }],
     };
   }
 );
 
+// ----------------------------------------
 // 5. リマインダー削除
+// ----------------------------------------
 server.tool(
   "delete_reminder",
   "リマインダーを削除",
@@ -183,27 +223,20 @@ server.tool(
     reminderName: z.string().describe("削除するリマインダー名"),
   },
   async ({ listName, reminderName }) => {
-    const script = `
-      tell application "Reminders"
-        tell list "${listName}"
-          delete (first reminder whose name is "${reminderName}")
-        end tell
-      end tell
-    `;
-
-    await runAppleScript(script);
+    const result = await runHelper([
+      "delete",
+      "--list", listName,
+      "--reminder", reminderName,
+    ]);
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `リマインダー「${reminderName}」を削除しました`,
-        },
-      ],
+      content: [{ type: "text" as const, text: result.message }],
     };
   }
 );
 
+// ----------------------------------------
 // 6. リマインダー更新
+// ----------------------------------------
 server.tool(
   "update_reminder",
   "リマインダーの内容を更新（名前、メモ、期日）",
@@ -216,49 +249,22 @@ server.tool(
     newDueDate: z.string().optional().describe('新しい期日（例: "2024-03-15 17:00"）'),
   },
   async ({ listName, reminderName, newName, newBody, appendBody, newDueDate }) => {
-    const updates: string[] = [];
+    const args = ["update", "--list", listName, "--reminder", reminderName];
+    if (newName) args.push("--new-name", newName);
+    if (newBody) args.push("--new-body", newBody);
+    if (appendBody) args.push("--append-body", appendBody);
+    if (newDueDate) args.push("--new-due-date", newDueDate);
 
-    if (newName) {
-      updates.push(`set name of r to "${newName}"`);
-    }
-    if (newBody) {
-      updates.push(`set body of r to "${newBody}"`);
-    }
-    if (appendBody) {
-      updates.push(`set body of r to (body of r) & "\n${appendBody}"`);
-    }
-    if (newDueDate) {
-      updates.push(`set due date of r to date "${newDueDate}"`);
-    }
-
-    if (updates.length === 0) {
-      return {
-        content: [{ type: "text" as const, text: "更新する項目が指定されていません" }],
-      };
-    }
-
-    const script = `
-      tell application "Reminders"
-        tell list "${listName}"
-          set r to (first reminder whose name is "${reminderName}")
-          ${updates.join("\n          ")}
-        end tell
-      end tell
-    `;
-
-    await runAppleScript(script);
+    const result = await runHelper(args);
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `リマインダー「${reminderName}」を更新しました`,
-        },
-      ],
+      content: [{ type: "text" as const, text: result.message }],
     };
   }
 );
 
+// ----------------------------------------
 // 7. 優先度設定
+// ----------------------------------------
 server.tool(
   "set_priority",
   "リマインダーの優先度を設定（0=なし, 1=高, 5=中, 9=低）",
@@ -268,28 +274,22 @@ server.tool(
     priority: z.number().min(0).max(9).describe("優先度（0=なし, 1=高, 5=中, 9=低）"),
   },
   async ({ listName, reminderName, priority }) => {
-    const script = `
-      tell application "Reminders"
-        tell list "${listName}"
-          set priority of (first reminder whose name is "${reminderName}") to ${priority}
-        end tell
-      end tell
-    `;
-
-    await runAppleScript(script);
-    const priorityLabel = priority === 0 ? "なし" : priority <= 3 ? "高" : priority <= 6 ? "中" : "低";
+    const result = await runHelper([
+      "set-priority",
+      "--list", listName,
+      "--reminder", reminderName,
+      "--priority", String(priority),
+    ]);
     return {
-      content: [
-        {
-          type: "text" as const,
-          text: `リマインダー「${reminderName}」の優先度を「${priorityLabel}」に設定しました`,
-        },
-      ],
+      content: [{ type: "text" as const, text: result.message }],
     };
   }
 );
 
-// 8. フラグ設定
+// ----------------------------------------
+// 8. フラグ設定（AppleScript フォールバック）
+// EventKit API にフラグ機能が存在しないため、AppleScript で処理
+// ----------------------------------------
 server.tool(
   "set_flag",
   "リマインダーのフラグを設定/解除",
@@ -319,7 +319,9 @@ server.tool(
   }
 );
 
+// ----------------------------------------
 // 9. 通知日時設定
+// ----------------------------------------
 server.tool(
   "set_remind_date",
   "リマインダーの通知日時を設定",
@@ -329,31 +331,212 @@ server.tool(
     remindDate: z.string().describe('通知日時（例: "2024-03-15 17:00"）'),
   },
   async ({ listName, reminderName, remindDate }) => {
-    const script = `
-      tell application "Reminders"
-        tell list "${listName}"
-          set remind me date of (first reminder whose name is "${reminderName}") to date "${remindDate}"
-        end tell
-      end tell
-    `;
+    const result = await runHelper([
+      "set-remind-date",
+      "--list", listName,
+      "--reminder", reminderName,
+      "--date", remindDate,
+    ]);
+    return {
+      content: [{ type: "text" as const, text: result.message }],
+    };
+  }
+);
 
-    await runAppleScript(script);
+// ============================================================
+// 新機能: 繰り返し（Issue #5）
+// ============================================================
+
+// ----------------------------------------
+// 10. 繰り返しルール取得
+// ----------------------------------------
+server.tool(
+  "get_recurrence",
+  "リマインダーの繰り返しルールを取得",
+  {
+    listName: z.string().describe("リスト名"),
+    reminderName: z.string().describe("リマインダー名"),
+  },
+  async ({ listName, reminderName }) => {
+    const result = await runHelper([
+      "get-recurrence",
+      "--list", listName,
+      "--reminder", reminderName,
+    ]);
     return {
       content: [
         {
           type: "text" as const,
-          text: `リマインダー「${reminderName}」の通知日時を「${remindDate}」に設定しました`,
+          text: result.message || JSON.stringify(result, null, 2),
         },
       ],
     };
   }
 );
 
+// ----------------------------------------
+// 11. 繰り返しルール設定
+// ----------------------------------------
+server.tool(
+  "set_recurrence",
+  "リマインダーに繰り返しルールを設定（日次/週次/月次/年次）",
+  {
+    listName: z.string().describe("リスト名"),
+    reminderName: z.string().describe("リマインダー名"),
+    frequency: z
+      .enum(["daily", "weekly", "monthly", "yearly"])
+      .describe("頻度（daily=毎日, weekly=毎週, monthly=毎月, yearly=毎年）"),
+    interval: z
+      .number()
+      .optional()
+      .default(1)
+      .describe("間隔（例: 2 → 2日ごと/2週ごと）"),
+    endCount: z
+      .number()
+      .optional()
+      .describe("終了回数（例: 10 → 10回で終了）"),
+    endDate: z
+      .string()
+      .optional()
+      .describe('終了日（例: "2024-12-31 23:59"）'),
+  },
+  async ({ listName, reminderName, frequency, interval, endCount, endDate }) => {
+    const args = [
+      "set-recurrence",
+      "--list", listName,
+      "--reminder", reminderName,
+      "--frequency", frequency,
+      "--interval", String(interval),
+    ];
+    if (endCount !== undefined) args.push("--end-count", String(endCount));
+    if (endDate) args.push("--end-date", endDate);
+
+    const result = await runHelper(args);
+    return {
+      content: [{ type: "text" as const, text: result.message }],
+    };
+  }
+);
+
+// ----------------------------------------
+// 12. 繰り返しルール解除
+// ----------------------------------------
+server.tool(
+  "clear_recurrence",
+  "リマインダーの繰り返しルールを解除",
+  {
+    listName: z.string().describe("リスト名"),
+    reminderName: z.string().describe("リマインダー名"),
+  },
+  async ({ listName, reminderName }) => {
+    const result = await runHelper([
+      "clear-recurrence",
+      "--list", listName,
+      "--reminder", reminderName,
+    ]);
+    return {
+      content: [{ type: "text" as const, text: result.message }],
+    };
+  }
+);
+
+// ============================================================
+// 新機能: 場所（Issue #6）
+// ============================================================
+
+// ----------------------------------------
+// 13. 場所情報取得
+// ----------------------------------------
+server.tool(
+  "get_location",
+  "リマインダーの場所情報を取得",
+  {
+    listName: z.string().describe("リスト名"),
+    reminderName: z.string().describe("リマインダー名"),
+  },
+  async ({ listName, reminderName }) => {
+    const result = await runHelper([
+      "get-location",
+      "--list", listName,
+      "--reminder", reminderName,
+    ]);
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: result.message || JSON.stringify(result, null, 2),
+        },
+      ],
+    };
+  }
+);
+
+// ----------------------------------------
+// 14. 場所ベースの通知設定
+// ----------------------------------------
+server.tool(
+  "set_location",
+  "リマインダーに場所ベースの通知を設定（到着時/出発時）",
+  {
+    listName: z.string().describe("リスト名"),
+    reminderName: z.string().describe("リマインダー名"),
+    title: z.string().describe("場所名（例: 職場）"),
+    latitude: z.number().describe("緯度"),
+    longitude: z.number().describe("経度"),
+    radius: z.number().optional().default(100).describe("半径（メートル、デフォルト: 100）"),
+    proximity: z
+      .enum(["enter", "leave"])
+      .optional()
+      .default("enter")
+      .describe("トリガー条件（enter=到着時, leave=出発時）"),
+  },
+  async ({ listName, reminderName, title, latitude, longitude, radius, proximity }) => {
+    const result = await runHelper([
+      "set-location",
+      "--list", listName,
+      "--reminder", reminderName,
+      "--title", title,
+      "--latitude", String(latitude),
+      "--longitude", String(longitude),
+      "--radius", String(radius),
+      "--proximity", proximity,
+    ]);
+    return {
+      content: [{ type: "text" as const, text: result.message }],
+    };
+  }
+);
+
+// ----------------------------------------
+// 15. 場所ベースの通知解除
+// ----------------------------------------
+server.tool(
+  "clear_location",
+  "リマインダーの場所ベース通知を解除",
+  {
+    listName: z.string().describe("リスト名"),
+    reminderName: z.string().describe("リマインダー名"),
+  },
+  async ({ listName, reminderName }) => {
+    const result = await runHelper([
+      "clear-location",
+      "--list", listName,
+      "--reminder", reminderName,
+    ]);
+    return {
+      content: [{ type: "text" as const, text: result.message }],
+    };
+  }
+);
+
+// ============================================================
 // サーバー起動
+// ============================================================
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("[apple-reminders-mcp] サーバー起動完了");
+  console.error("[apple-reminders-mcp] サーバー起動完了 (v2.0.0 - EventKit backend)");
 }
 
 main().catch(console.error);

--- a/swift-helper/Package.resolved
+++ b/swift-helper/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/swift-helper/Package.swift
+++ b/swift-helper/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "RemindersHelper",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "reminders-helper",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Sources"
+        ),
+    ]
+)

--- a/swift-helper/Sources/CRUDCommands.swift
+++ b/swift-helper/Sources/CRUDCommands.swift
@@ -1,0 +1,182 @@
+/**
+ * CRUD コマンド
+ * - add: リマインダー追加
+ * - complete: リマインダー完了
+ * - delete: リマインダー削除
+ * - update: リマインダー更新
+ */
+
+import ArgumentParser
+import EventKit
+
+// ----------------------------------------
+// リマインダー追加
+// ----------------------------------------
+struct AddReminder: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "add",
+        abstract: "新しいリマインダーを追加"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Option(name: .long, help: "タイトル")
+    var title: String
+
+    @Option(name: .long, help: "メモ")
+    var body: String?
+
+    @Option(name: .long, help: "期日 (例: 2024-03-15 09:00)")
+    var dueDate: String?
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let calendar = try manager.findList(name: list)
+
+        let reminder = EKReminder(eventStore: manager.store)
+        reminder.calendar = calendar
+        reminder.title = title
+        reminder.notes = body
+
+        if let dueDateStr = dueDate {
+            let date = try manager.parseDate(dueDateStr)
+            reminder.dueDateComponents = manager.dateToComponents(date)
+        }
+
+        try manager.save(reminder)
+        try outputJSON(SuccessOutput(
+            success: true,
+            message: "リマインダー「\(title)」を「\(list)」に追加しました"
+        ))
+    }
+}
+
+// ----------------------------------------
+// リマインダー完了
+// ----------------------------------------
+struct CompleteReminder: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "complete",
+        abstract: "リマインダーを完了にする"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Option(name: .long, help: "リマインダー名")
+    var reminder: String
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let target = try await manager.findReminder(
+            listName: list,
+            reminderName: reminder
+        )
+        target.isCompleted = true
+        try manager.save(target)
+        try outputJSON(SuccessOutput(
+            success: true,
+            message: "リマインダー「\(reminder)」を完了にしました"
+        ))
+    }
+}
+
+// ----------------------------------------
+// リマインダー削除
+// ----------------------------------------
+struct DeleteReminder: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "delete",
+        abstract: "リマインダーを削除"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Option(name: .long, help: "リマインダー名")
+    var reminder: String
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let target = try await manager.findReminder(
+            listName: list,
+            reminderName: reminder
+        )
+        try manager.remove(target)
+        try outputJSON(SuccessOutput(
+            success: true,
+            message: "リマインダー「\(reminder)」を削除しました"
+        ))
+    }
+}
+
+// ----------------------------------------
+// リマインダー更新
+// ----------------------------------------
+struct UpdateReminder: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "update",
+        abstract: "リマインダーの内容を更新"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Option(name: .long, help: "リマインダー名")
+    var reminder: String
+
+    @Option(name: .long, help: "新しい名前")
+    var newName: String?
+
+    @Option(name: .long, help: "新しいメモ（上書き）")
+    var newBody: String?
+
+    @Option(name: .long, help: "メモに追記する内容")
+    var appendBody: String?
+
+    @Option(name: .long, help: "新しい期日 (例: 2024-03-15 09:00)")
+    var newDueDate: String?
+
+    func run() async throws {
+        // 更新項目がない場合は早期リターン
+        guard newName != nil || newBody != nil
+            || appendBody != nil || newDueDate != nil else {
+            try outputJSON(SuccessOutput(
+                success: false,
+                message: "更新する項目が指定されていません"
+            ))
+            return
+        }
+
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let target = try await manager.findReminder(
+            listName: list,
+            reminderName: reminder
+        )
+
+        if let name = newName {
+            target.title = name
+        }
+        if let body = newBody {
+            target.notes = body
+        }
+        if let append = appendBody {
+            target.notes = (target.notes ?? "") + "\n" + append
+        }
+        if let dueDateStr = newDueDate {
+            let date = try manager.parseDate(dueDateStr)
+            target.dueDateComponents = manager.dateToComponents(date)
+        }
+
+        try manager.save(target)
+        try outputJSON(SuccessOutput(
+            success: true,
+            message: "リマインダー「\(reminder)」を更新しました"
+        ))
+    }
+}

--- a/swift-helper/Sources/EventKitManager.swift
+++ b/swift-helper/Sources/EventKitManager.swift
@@ -1,0 +1,259 @@
+/**
+ * EventKit ラッパー
+ *
+ * Reminders.app への全アクセスをこのクラスに集約する
+ * - アクセス権限のリクエスト
+ * - リスト・リマインダーの検索
+ * - CRUD 操作
+ * - EKReminder → ReminderOutput への変換
+ */
+
+import EventKit
+import Foundation
+import CoreLocation
+
+// ============================================================
+// エラー定義
+// ============================================================
+
+enum RemindersError: Error, LocalizedError {
+    case accessDenied
+    case listNotFound(String)
+    case reminderNotFound(String)
+    case fetchFailed
+    case saveFailed(String)
+    case invalidDate(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .accessDenied:
+            return "リマインダーへのアクセスが拒否されました"
+        case .listNotFound(let name):
+            return "リストが見つかりません: \(name)"
+        case .reminderNotFound(let name):
+            return "リマインダーが見つかりません: \(name)"
+        case .fetchFailed:
+            return "リマインダーの取得に失敗しました"
+        case .saveFailed(let msg):
+            return "保存に失敗しました: \(msg)"
+        case .invalidDate(let str):
+            return "無効な日付形式です: \(str) (期待形式: yyyy-MM-dd HH:mm)"
+        }
+    }
+}
+
+// ============================================================
+// EventKitManager 本体
+// ============================================================
+
+class EventKitManager {
+    let store = EKEventStore()
+
+    /// 日付フォーマッター（"yyyy-MM-dd HH:mm" 形式）
+    static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    // ----------------------------------------
+    // アクセス権限
+    // ----------------------------------------
+
+    /// リマインダーへのフルアクセスをリクエスト
+    /// 初回実行時はシステムダイアログが表示される
+    func requestAccess() async throws {
+        let granted = try await store.requestFullAccessToReminders()
+        guard granted else { throw RemindersError.accessDenied }
+    }
+
+    // ----------------------------------------
+    // リスト操作
+    // ----------------------------------------
+
+    /// 全リストを取得
+    func getAllLists() -> [EKCalendar] {
+        return store.calendars(for: .reminder)
+    }
+
+    /// リストを名前で検索
+    func findList(name: String) throws -> EKCalendar {
+        guard let calendar = store.calendars(for: .reminder)
+            .first(where: { $0.title == name }) else {
+            throw RemindersError.listNotFound(name)
+        }
+        return calendar
+    }
+
+    // ----------------------------------------
+    // リマインダー取得
+    // ----------------------------------------
+
+    /// 指定リストのリマインダーを全取得
+    func fetchReminders(
+        in calendar: EKCalendar,
+        includeCompleted: Bool = false
+    ) async throws -> [EKReminder] {
+        let predicate = store.predicateForReminders(in: [calendar])
+        return try await withCheckedThrowingContinuation { continuation in
+            store.fetchReminders(matching: predicate) { reminders in
+                guard let reminders = reminders else {
+                    continuation.resume(throwing: RemindersError.fetchFailed)
+                    return
+                }
+                let filtered = includeCompleted
+                    ? reminders
+                    : reminders.filter { !$0.isCompleted }
+                continuation.resume(returning: filtered)
+            }
+        }
+    }
+
+    /// リマインダーを名前で検索
+    func findReminder(listName: String, reminderName: String) async throws -> EKReminder {
+        let calendar = try findList(name: listName)
+        let reminders = try await fetchReminders(in: calendar, includeCompleted: true)
+        guard let reminder = reminders.first(where: { $0.title == reminderName }) else {
+            throw RemindersError.reminderNotFound(reminderName)
+        }
+        return reminder
+    }
+
+    // ----------------------------------------
+    // 保存・削除
+    // ----------------------------------------
+
+    /// リマインダーを保存（新規作成・更新共通）
+    func save(_ reminder: EKReminder) throws {
+        do {
+            try store.save(reminder, commit: true)
+        } catch {
+            throw RemindersError.saveFailed(error.localizedDescription)
+        }
+    }
+
+    /// リマインダーを削除
+    func remove(_ reminder: EKReminder) throws {
+        do {
+            try store.remove(reminder, commit: true)
+        } catch {
+            throw RemindersError.saveFailed(error.localizedDescription)
+        }
+    }
+
+    // ----------------------------------------
+    // 日付ユーティリティ
+    // ----------------------------------------
+
+    /// 文字列 → Date に変換
+    func parseDate(_ dateString: String) throws -> Date {
+        guard let date = Self.dateFormatter.date(from: dateString) else {
+            throw RemindersError.invalidDate(dateString)
+        }
+        return date
+    }
+
+    /// Date → DateComponents に変換
+    func dateToComponents(_ date: Date) -> DateComponents {
+        return Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute],
+            from: date
+        )
+    }
+
+    // ----------------------------------------
+    // EKReminder → ReminderOutput 変換
+    // ----------------------------------------
+
+    /// EKReminder を JSON 出力用の ReminderOutput に変換
+    func toOutput(_ reminder: EKReminder) -> ReminderOutput {
+        // 期日
+        var dueDateStr: String? = nil
+        if let components = reminder.dueDateComponents,
+           let date = Calendar.current.date(from: components) {
+            dueDateStr = Self.dateFormatter.string(from: date)
+        }
+
+        // 繰り返し情報
+        let hasRecurrence = reminder.hasRecurrenceRules
+            && !(reminder.recurrenceRules?.isEmpty ?? true)
+        var recurrenceInfo: RecurrenceInfo? = nil
+        if hasRecurrence, let rule = reminder.recurrenceRules?.first {
+            recurrenceInfo = ruleToInfo(rule)
+        }
+
+        // 場所情報
+        var locationInfo: LocationInfo? = nil
+        var hasLocation = false
+        if let alarms = reminder.alarms {
+            for alarm in alarms {
+                if let loc = alarm.structuredLocation,
+                   let geo = loc.geoLocation {
+                    hasLocation = true
+                    let prox: String
+                    switch alarm.proximity {
+                    case .enter: prox = "enter"
+                    case .leave: prox = "leave"
+                    default: prox = "none"
+                    }
+                    locationInfo = LocationInfo(
+                        title: loc.title,
+                        latitude: geo.coordinate.latitude,
+                        longitude: geo.coordinate.longitude,
+                        radius: loc.radius,
+                        proximity: prox
+                    )
+                    break
+                }
+            }
+        }
+
+        return ReminderOutput(
+            title: reminder.title ?? "",
+            body: reminder.notes,
+            completed: reminder.isCompleted,
+            dueDate: dueDateStr,
+            priority: reminder.priority,
+            // isFlagged は EventKit API に存在しない（AppleScript でのみ操作可能）
+            flagged: false,
+            hasRecurrence: hasRecurrence,
+            recurrence: recurrenceInfo,
+            hasLocation: hasLocation,
+            location: locationInfo
+        )
+    }
+
+    /// EKRecurrenceRule → RecurrenceInfo に変換
+    private func ruleToInfo(_ rule: EKRecurrenceRule) -> RecurrenceInfo {
+        let freq: String
+        switch rule.frequency {
+        case .daily: freq = "daily"
+        case .weekly: freq = "weekly"
+        case .monthly: freq = "monthly"
+        case .yearly: freq = "yearly"
+        @unknown default: freq = "unknown"
+        }
+
+        var endDate: String? = nil
+        var endCount: Int? = nil
+        if let end = rule.recurrenceEnd {
+            if let date = end.endDate {
+                endDate = Self.dateFormatter.string(from: date)
+            }
+            if end.occurrenceCount > 0 {
+                endCount = end.occurrenceCount
+            }
+        }
+
+        let daysOfWeek = rule.daysOfTheWeek?.map { $0.dayOfTheWeek.rawValue }
+
+        return RecurrenceInfo(
+            frequency: freq,
+            interval: rule.interval,
+            endDate: endDate,
+            endCount: endCount,
+            daysOfWeek: daysOfWeek
+        )
+    }
+}

--- a/swift-helper/Sources/ListCommands.swift
+++ b/swift-helper/Sources/ListCommands.swift
@@ -1,0 +1,55 @@
+/**
+ * リスト操作コマンド
+ * - list-lists: リスト一覧取得
+ * - get-reminders: 指定リストのリマインダー一覧取得
+ */
+
+import ArgumentParser
+import EventKit
+
+// ----------------------------------------
+// リスト一覧取得
+// ----------------------------------------
+struct ListLists: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list-lists",
+        abstract: "リマインダーリスト一覧を取得"
+    )
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let lists = manager.getAllLists().map { $0.title }
+        try outputJSON(ListsOutput(lists: lists))
+    }
+}
+
+// ----------------------------------------
+// リマインダー一覧取得
+// ----------------------------------------
+struct GetReminders: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "get-reminders",
+        abstract: "指定リストのリマインダー一覧を取得"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Flag(name: .long, help: "完了済みも含める")
+    var includeCompleted = false
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let calendar = try manager.findList(name: list)
+        let reminders = try await manager.fetchReminders(
+            in: calendar,
+            includeCompleted: includeCompleted
+        )
+        let output = RemindersOutput(
+            reminders: reminders.map { manager.toOutput($0) }
+        )
+        try outputJSON(output)
+    }
+}

--- a/swift-helper/Sources/LocationCommands.swift
+++ b/swift-helper/Sources/LocationCommands.swift
@@ -1,0 +1,171 @@
+/**
+ * 場所コマンド（新機能 - Issue #6）
+ * - get-location: 場所情報取得
+ * - set-location: 場所ベースの通知設定
+ * - clear-location: 場所ベースの通知解除
+ *
+ * EventKit の EKStructuredLocation + EKAlarm.proximity を使用
+ * AppleScript では対応できない機能
+ *
+ * 注意: 座標（緯度経度）は直接指定する必要がある
+ * CLIツールでは現在地の自動取得ができないため
+ */
+
+import ArgumentParser
+import EventKit
+import CoreLocation
+
+// ----------------------------------------
+// 場所情報取得
+// ----------------------------------------
+struct GetLocation: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "get-location",
+        abstract: "リマインダーの場所情報を取得"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Option(name: .long, help: "リマインダー名")
+    var reminder: String
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let target = try await manager.findReminder(
+            listName: list,
+            reminderName: reminder
+        )
+        let output = manager.toOutput(target)
+
+        if let location = output.location {
+            try outputJSON(location)
+        } else {
+            try outputJSON(SuccessOutput(
+                success: true,
+                message: "場所ベースの通知は設定されていません"
+            ))
+        }
+    }
+}
+
+// ----------------------------------------
+// 場所ベースの通知設定
+// ----------------------------------------
+struct SetLocation: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "set-location",
+        abstract: "リマインダーに場所ベースの通知を設定"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Option(name: .long, help: "リマインダー名")
+    var reminder: String
+
+    @Option(name: .long, help: "場所名（例: 職場）")
+    var title: String
+
+    @Option(name: .long, help: "緯度")
+    var latitude: Double
+
+    @Option(name: .long, help: "経度")
+    var longitude: Double
+
+    @Option(name: .long, help: "半径（メートル、デフォルト: 100）")
+    var radius: Double = 100.0
+
+    @Option(name: .long, help: "トリガー条件 (enter=到着時, leave=出発時)")
+    var proximity: String = "enter"
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let target = try await manager.findReminder(
+            listName: list,
+            reminderName: reminder
+        )
+
+        // proximity を変換
+        let ekProximity: EKAlarmProximity
+        switch proximity.lowercased() {
+        case "enter": ekProximity = .enter
+        case "leave": ekProximity = .leave
+        default:
+            try outputJSON(SuccessOutput(
+                success: false,
+                message: "無効なトリガー条件: \(proximity) (enter/leave)"
+            ))
+            return
+        }
+
+        // 既存の場所ベースアラームを削除
+        if let existingAlarms = target.alarms {
+            for alarm in existingAlarms where alarm.structuredLocation != nil {
+                target.removeAlarm(alarm)
+            }
+        }
+
+        // 場所情報を設定
+        let location = EKStructuredLocation(title: title)
+        location.geoLocation = CLLocation(
+            latitude: latitude,
+            longitude: longitude
+        )
+        location.radius = radius
+
+        // アラームを作成して追加
+        let alarm = EKAlarm()
+        alarm.structuredLocation = location
+        alarm.proximity = ekProximity
+        target.addAlarm(alarm)
+
+        try manager.save(target)
+
+        let triggerLabel = proximity == "enter" ? "到着時" : "出発時"
+        try outputJSON(SuccessOutput(
+            success: true,
+            message: "リマインダー「\(reminder)」に場所通知を設定しました（\(title) - \(triggerLabel)）"
+        ))
+    }
+}
+
+// ----------------------------------------
+// 場所ベースの通知解除
+// ----------------------------------------
+struct ClearLocation: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "clear-location",
+        abstract: "リマインダーの場所ベース通知を解除"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Option(name: .long, help: "リマインダー名")
+    var reminder: String
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let target = try await manager.findReminder(
+            listName: list,
+            reminderName: reminder
+        )
+
+        // 場所ベースのアラームのみ削除（日時ベースは残す）
+        if let alarms = target.alarms {
+            for alarm in alarms where alarm.structuredLocation != nil {
+                target.removeAlarm(alarm)
+            }
+        }
+
+        try manager.save(target)
+        try outputJSON(SuccessOutput(
+            success: true,
+            message: "リマインダー「\(reminder)」の場所ベース通知を解除しました"
+        ))
+    }
+}

--- a/swift-helper/Sources/Models.swift
+++ b/swift-helper/Sources/Models.swift
@@ -1,0 +1,79 @@
+/**
+ * JSON 出力用のモデル定義
+ *
+ * 全コマンドの出力は Codable な構造体として定義し、
+ * outputJSON() で JSON 文字列に変換して stdout に出力する
+ */
+
+import Foundation
+
+// ============================================================
+// 出力ヘルパー
+// ============================================================
+
+/// Codable な値を JSON 文字列として stdout に出力する
+func outputJSON<T: Encodable>(_ value: T) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(value)
+    print(String(data: data, encoding: .utf8)!)
+}
+
+/// エラーメッセージを JSON 形式で stdout に出力する
+func outputError(_ message: String) {
+    // エラーもJSONで返す（TypeScript側でパースしやすい）
+    let json = "{\"error\": \"\(message.replacingOccurrences(of: "\"", with: "\\\""))\"}"
+    print(json)
+}
+
+// ============================================================
+// 出力モデル
+// ============================================================
+
+/// リスト一覧
+struct ListsOutput: Codable {
+    let lists: [String]
+}
+
+/// リマインダー1件の情報
+struct ReminderOutput: Codable {
+    let title: String
+    let body: String?
+    let completed: Bool
+    let dueDate: String?
+    let priority: Int
+    let flagged: Bool
+    let hasRecurrence: Bool
+    let recurrence: RecurrenceInfo?
+    let hasLocation: Bool
+    let location: LocationInfo?
+}
+
+/// リマインダー一覧
+struct RemindersOutput: Codable {
+    let reminders: [ReminderOutput]
+}
+
+/// 繰り返し情報
+struct RecurrenceInfo: Codable {
+    let frequency: String   // daily, weekly, monthly, yearly
+    let interval: Int
+    let endDate: String?
+    let endCount: Int?
+    let daysOfWeek: [Int]?  // 1=Sunday, 2=Monday, ...
+}
+
+/// 場所情報
+struct LocationInfo: Codable {
+    let title: String?
+    let latitude: Double
+    let longitude: Double
+    let radius: Double
+    let proximity: String   // enter, leave, none
+}
+
+/// 成功レスポンス
+struct SuccessOutput: Codable {
+    let success: Bool
+    let message: String
+}

--- a/swift-helper/Sources/PropertyCommands.swift
+++ b/swift-helper/Sources/PropertyCommands.swift
@@ -1,0 +1,95 @@
+/**
+ * プロパティ設定コマンド
+ * - set-priority: 優先度設定
+ * - set-flag: フラグ設定
+ * - set-remind-date: 通知日時設定
+ */
+
+import ArgumentParser
+import EventKit
+
+// ----------------------------------------
+// 優先度設定
+// ----------------------------------------
+struct SetPriority: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "set-priority",
+        abstract: "リマインダーの優先度を設定（0=なし, 1=高, 5=中, 9=低）"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Option(name: .long, help: "リマインダー名")
+    var reminder: String
+
+    @Option(name: .long, help: "優先度（0=なし, 1=高, 5=中, 9=低）")
+    var priority: Int
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let target = try await manager.findReminder(
+            listName: list,
+            reminderName: reminder
+        )
+        target.priority = priority
+        try manager.save(target)
+
+        let label = priority == 0 ? "なし"
+            : priority <= 3 ? "高"
+            : priority <= 6 ? "中" : "低"
+        try outputJSON(SuccessOutput(
+            success: true,
+            message: "リマインダー「\(reminder)」の優先度を「\(label)」に設定しました"
+        ))
+    }
+}
+
+// フラグ設定は EventKit API に存在しないため、AppleScript で処理する
+// TypeScript 側で osascript にフォールバックする
+
+// ----------------------------------------
+// 通知日時設定
+// ----------------------------------------
+struct SetRemindDate: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "set-remind-date",
+        abstract: "リマインダーの通知日時を設定"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Option(name: .long, help: "リマインダー名")
+    var reminder: String
+
+    @Option(name: .long, help: "通知日時 (例: 2024-03-15 09:00)")
+    var date: String
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let target = try await manager.findReminder(
+            listName: list,
+            reminderName: reminder
+        )
+
+        let remindDate = try manager.parseDate(date)
+        let alarm = EKAlarm(absoluteDate: remindDate)
+
+        // 既存の日時ベースアラームを削除してから追加
+        if let existingAlarms = target.alarms {
+            for existing in existingAlarms where existing.absoluteDate != nil {
+                target.removeAlarm(existing)
+            }
+        }
+        target.addAlarm(alarm)
+
+        try manager.save(target)
+        try outputJSON(SuccessOutput(
+            success: true,
+            message: "リマインダー「\(reminder)」の通知日時を「\(date)」に設定しました"
+        ))
+    }
+}

--- a/swift-helper/Sources/RecurrenceCommands.swift
+++ b/swift-helper/Sources/RecurrenceCommands.swift
@@ -1,0 +1,176 @@
+/**
+ * 繰り返しコマンド（新機能 - Issue #5）
+ * - get-recurrence: 繰り返しルール取得
+ * - set-recurrence: 繰り返しルール設定
+ * - clear-recurrence: 繰り返しルール解除
+ *
+ * EventKit の EKRecurrenceRule を使用
+ * AppleScript では対応できない機能
+ */
+
+import ArgumentParser
+import EventKit
+
+// ----------------------------------------
+// 繰り返しルール取得
+// ----------------------------------------
+struct GetRecurrence: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "get-recurrence",
+        abstract: "リマインダーの繰り返しルールを取得"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Option(name: .long, help: "リマインダー名")
+    var reminder: String
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let target = try await manager.findReminder(
+            listName: list,
+            reminderName: reminder
+        )
+        let output = manager.toOutput(target)
+
+        if let recurrence = output.recurrence {
+            try outputJSON(recurrence)
+        } else {
+            try outputJSON(SuccessOutput(
+                success: true,
+                message: "繰り返しルールは設定されていません"
+            ))
+        }
+    }
+}
+
+// ----------------------------------------
+// 繰り返しルール設定
+// ----------------------------------------
+struct SetRecurrence: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "set-recurrence",
+        abstract: "リマインダーに繰り返しルールを設定"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Option(name: .long, help: "リマインダー名")
+    var reminder: String
+
+    @Option(name: .long, help: "頻度 (daily, weekly, monthly, yearly)")
+    var frequency: String
+
+    @Option(name: .long, help: "間隔（例: 2 → 2日ごと/2週ごと）")
+    var interval: Int = 1
+
+    @Option(name: .long, help: "終了回数（例: 10 → 10回で終了）")
+    var endCount: Int?
+
+    @Option(name: .long, help: "終了日 (例: 2024-12-31 23:59)")
+    var endDate: String?
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let target = try await manager.findReminder(
+            listName: list,
+            reminderName: reminder
+        )
+
+        // 頻度を変換
+        let freq: EKRecurrenceFrequency
+        switch frequency.lowercased() {
+        case "daily": freq = .daily
+        case "weekly": freq = .weekly
+        case "monthly": freq = .monthly
+        case "yearly": freq = .yearly
+        default:
+            try outputJSON(SuccessOutput(
+                success: false,
+                message: "無効な頻度: \(frequency) (daily/weekly/monthly/yearly)"
+            ))
+            return
+        }
+
+        // 終了条件を設定
+        var end: EKRecurrenceEnd? = nil
+        if let count = endCount {
+            end = EKRecurrenceEnd(occurrenceCount: count)
+        } else if let dateStr = endDate {
+            let date = try manager.parseDate(dateStr)
+            end = EKRecurrenceEnd(end: date)
+        }
+
+        // 既存の繰り返しルールを削除
+        if let existingRules = target.recurrenceRules {
+            for rule in existingRules {
+                target.removeRecurrenceRule(rule)
+            }
+        }
+
+        // 新しいルールを追加
+        let rule = EKRecurrenceRule(
+            recurrenceWith: freq,
+            interval: interval,
+            end: end
+        )
+        target.addRecurrenceRule(rule)
+
+        try manager.save(target)
+
+        let freqLabel: String
+        switch frequency.lowercased() {
+        case "daily": freqLabel = interval == 1 ? "毎日" : "\(interval)日ごと"
+        case "weekly": freqLabel = interval == 1 ? "毎週" : "\(interval)週ごと"
+        case "monthly": freqLabel = interval == 1 ? "毎月" : "\(interval)ヶ月ごと"
+        case "yearly": freqLabel = interval == 1 ? "毎年" : "\(interval)年ごと"
+        default: freqLabel = frequency
+        }
+
+        try outputJSON(SuccessOutput(
+            success: true,
+            message: "リマインダー「\(reminder)」に繰り返し「\(freqLabel)」を設定しました"
+        ))
+    }
+}
+
+// ----------------------------------------
+// 繰り返しルール解除
+// ----------------------------------------
+struct ClearRecurrence: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "clear-recurrence",
+        abstract: "リマインダーの繰り返しルールを解除"
+    )
+
+    @Option(name: .long, help: "リスト名")
+    var list: String
+
+    @Option(name: .long, help: "リマインダー名")
+    var reminder: String
+
+    func run() async throws {
+        let manager = EventKitManager()
+        try await manager.requestAccess()
+        let target = try await manager.findReminder(
+            listName: list,
+            reminderName: reminder
+        )
+
+        if let rules = target.recurrenceRules {
+            for rule in rules {
+                target.removeRecurrenceRule(rule)
+            }
+        }
+
+        try manager.save(target)
+        try outputJSON(SuccessOutput(
+            success: true,
+            message: "リマインダー「\(reminder)」の繰り返しルールを解除しました"
+        ))
+    }
+}

--- a/swift-helper/Sources/RemindersHelper.swift
+++ b/swift-helper/Sources/RemindersHelper.swift
@@ -1,0 +1,40 @@
+/**
+ * reminders-helper
+ *
+ * Apple Reminders を EventKit 経由で操作する CLI ツール
+ * apple-reminders-mcp の TypeScript MCP サーバーから呼び出される
+ *
+ * 全コマンドは JSON を stdout に出力する
+ */
+
+import ArgumentParser
+
+@main
+struct RemindersHelper: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "reminders-helper",
+        abstract: "Apple Reminders EventKit CLI ヘルパー",
+        subcommands: [
+            // リスト操作
+            ListLists.self,
+            GetReminders.self,
+            // CRUD
+            AddReminder.self,
+            CompleteReminder.self,
+            DeleteReminder.self,
+            UpdateReminder.self,
+            // プロパティ
+            SetPriority.self,
+            // SetFlag は EventKit 未対応のため AppleScript で処理
+            SetRemindDate.self,
+            // 繰り返し（新機能）
+            GetRecurrence.self,
+            SetRecurrence.self,
+            ClearRecurrence.self,
+            // 場所（新機能）
+            GetLocation.self,
+            SetLocation.self,
+            ClearLocation.self,
+        ]
+    )
+}


### PR DESCRIPTION
## Summary
- AppleScript から EventKit (Swift CLI) にバックエンドを全面移行
- 繰り返しルール機能を追加 (#5)
- 場所ベース通知機能を追加 (#6)
- Epic: EventKit (Swift) 対応を完了 (#3)

## 変更内容

### 新規: `swift-helper/`
Swift Package Manager プロジェクト。EventKit 経由で全リマインダー操作を実装。
- `reminders-helper` CLI（サブコマンド方式 + JSON 出力）
- swift-argument-parser 依存

### 改修: `src/index.ts` (v1.0.0 → v2.0.0)
- 全ツールのバックエンドを Swift CLI に移行
- フラグ設定のみ AppleScript フォールバック（EventKit API 未対応）
- 新ツール 6個追加: get/set/clear_recurrence, get/set/clear_location

### その他
- `.gitignore` に Swift ビルド成果物を追加

## 既知の制限
- `isFlagged` が EventKit API に存在しないため、フラグ操作のみ AppleScript を継続使用
- Tags (#4) は EventKit / AppleScript ともに API 未公開のため not planned でクローズ

## Test plan
- [x] Swift CLI ビルド成功（`swift build -c release`）
- [x] TypeScript 型チェック通過（`bun x tsc --noEmit`）
- [x] MCP サーバー起動確認（v2.0.0 EventKit backend）
- [x] 既存ツール動作確認（list, get, add, delete）
- [x] 繰り返し設定/取得/解除 動作確認
- [x] 場所設定/取得/解除 動作確認

Closes #3, Closes #5, Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)