### PR TITLE
docs: README を EventKit 移行後に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 macOS Reminders.app を操作する MCP (Model Context Protocol) サーバー。
 
-macOS 26 で既存の MCP サーバー（apple-mcp 等）が動作しなくなったため、osascript を直接ラップするシンプルな実装として作成。
+EventKit (Swift CLI) をバックエンドとして使用し、繰り返し・場所ベース通知など高度な機能に対応。
 
 ## 機能
+
+### 基本操作
 
 | ツール | 説明 |
 |--------|------|
@@ -14,22 +16,54 @@ macOS 26 で既存の MCP サーバー（apple-mcp 等）が動作しなくな�
 | `complete_reminder` | リマインダーを完了にする |
 | `delete_reminder` | リマインダーを削除 |
 | `update_reminder` | リマインダーの内容を更新（名前、メモ、期日） |
+
+### プロパティ設定
+
+| ツール | 説明 |
+|--------|------|
 | `set_priority` | 優先度を設定（0=なし, 1=高, 5=中, 9=低） |
 | `set_flag` | フラグを設定/解除 |
 | `set_remind_date` | 通知日時を設定 |
 
-### 未対応（AppleScript制限）
+### 繰り返し（EventKit）
 
-以下の機能はAppleScriptでは対応できないため、将来的にEventKit（Swift）で対応予定：
+| ツール | 説明 |
+|--------|------|
+| `get_recurrence` | 繰り返しルールを取得 |
+| `set_recurrence` | 繰り返しルールを設定（日次/週次/月次/年次） |
+| `clear_recurrence` | 繰り返しルールを解除 |
 
-- タグ
-- 繰り返し（日次/週次など）
-- 場所
+### 場所ベース通知（EventKit）
+
+| ツール | 説明 |
+|--------|------|
+| `get_location` | 場所情報を取得 |
+| `set_location` | 場所ベースの通知を設定（到着時/出発時） |
+| `clear_location` | 場所ベース通知を解除 |
+
+### API 制限
+
+| 機能 | 状態 | 備考 |
+|------|------|------|
+| タグ | 未対応 | EventKit / AppleScript ともに API 未公開（[#4](https://github.com/r4sd/apple-reminders-mcp/issues/4)） |
+| フラグ | AppleScript | EventKit に `isFlagged` プロパティが存在しないため AppleScript で処理 |
+
+## アーキテクチャ
+
+```
+TypeScript MCP Server (Bun)
+  ├─ Swift CLI (EventKit)     → メイン: 全操作を担当
+  └─ osascript (AppleScript)  → フォールバック: フラグ設定のみ
+```
+
+Swift CLI ヘルパー (`swift-helper/`) は EventKit 経由で Reminders.app を操作し、JSON で結果を返す。
+TypeScript MCP サーバー (`src/index.ts`) が CLI を呼び出して Claude との通信を仲介する。
 
 ## 必要環境
 
-- macOS
+- macOS 14 (Sonoma) 以上
 - [Bun](https://bun.sh/) v1.0 以上
+- Swift 5.9 以上（Xcode 付属）
 - Reminders.app へのアクセス権限
 
 ## インストール
@@ -37,15 +71,22 @@ macOS 26 で既存の MCP サーバー（apple-mcp 等）が動作しなくな�
 ```bash
 git clone https://github.com/r4sd/apple-reminders-mcp.git
 cd apple-reminders-mcp
+
+# 依存パッケージをインストール
 bun install
+
+# Swift CLI ヘルパーをビルド
+cd swift-helper && swift build -c release && cd ..
 ```
+
+> 初回実行時に Reminders.app へのアクセス許可ダイアログが表示されます。
 
 ## 使い方
 
 ### Claude Code で使用
 
 ```bash
-claude mcp add apple-reminders -- bun /path/to/apple-reminders-mcp/src/index.ts
+claude mcp add apple-reminders-mcp -- bun /path/to/apple-reminders-mcp/src/index.ts
 ```
 
 ### Claude Desktop で使用
@@ -55,7 +96,7 @@ claude mcp add apple-reminders -- bun /path/to/apple-reminders-mcp/src/index.ts
 ```json
 {
   "mcpServers": {
-    "apple-reminders": {
+    "apple-reminders-mcp": {
       "command": "bun",
       "args": ["/path/to/apple-reminders-mcp/src/index.ts"]
     }
@@ -66,7 +107,12 @@ claude mcp add apple-reminders -- bun /path/to/apple-reminders-mcp/src/index.ts
 ### 動作確認
 
 ```bash
+# MCP サーバー起動
 bun src/index.ts
+
+# Swift CLI 単体テスト
+swift-helper/.build/release/reminders-helper list-lists
+swift-helper/.build/release/reminders-helper get-reminders --list "Backlog"
 ```
 
 ## ライセンス


### PR DESCRIPTION
## Summary
- アーキテクチャ説明を EventKit (Swift CLI) バックエンドに更新
- 新ツール6個（繰り返し・場所）をツール一覧に追加
- API制限・インストール手順・必要環境を現状に合わせて更新

## Test plan
- [x] README の内容が実装と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)