### PR TITLE
ci: dependabot の patch/minor を CI 通過後に自動マージ

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+
+# dependabot の PR のうち patch/minor 更新を CI 通過後に自動マージする。
+# major 更新は breaking の可能性があるため自動マージせず手動レビューに回す。
+# auto-merge は branch protection の required status check (typecheck) 通過を待ってから実行される。
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge patch/minor
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Enable auto-merge for patch/minor
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

dependabot の patch/minor 更新を CI 通過後に自動マージする (go-wsman と同じ仕組み)。major は手動レビュー。

## 仕組み

- `dependabot/fetch-metadata` (SHA ピン留め v3.1.0) で update-type 判定
- patch/minor → `gh pr merge --auto --squash`
- major → 手動
- branch protection の required check (typecheck) 通過後にマージ

## 安全性

- required check (typecheck) が安全網
- private リポ (npm publish なし) のため依存更新の外部影響なし
- 対象 ecosystem: npm + github-actions の patch/minor

## 補足: macOS Compatibility Check の無効化について

別途 `macos-compat.yml` が `disabled_inactivity` (90 日トリガーなしで GitHub が自動無効化) になっています。required check ではないため auto-merge には影響しませんが、macOS 実機の Swift スモークテストが止まっている状態です。再有効化 or 運用見直しは別途ご検討ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)